### PR TITLE
Add USB boot mode management for HS/FS polling rates

### DIFF
--- a/src/ap/modules/qmk/port/port.h
+++ b/src/ap/modules/qmk/port/port.h
@@ -18,3 +18,5 @@
 #define EECONFIG_USER_KILL_SWITCH_LR  ((void *)((uint32_t)EECONFIG_USER_DATABLOCK +  8)) // 8B
 #define EECONFIG_USER_KILL_SWITCH_UD  ((void *)((uint32_t)EECONFIG_USER_DATABLOCK + 16)) // 8B
 #define EECONFIG_USER_KKUK            ((void *)((uint32_t)EECONFIG_USER_DATABLOCK + 24)) // 4B
+// [V250628R1] Reserve EEPROM slot for USB boot mode selection.
+#define EECONFIG_USER_BOOTMODE        ((void *)((uint32_t)EECONFIG_USER_DATABLOCK + 28)) // 4B

--- a/src/hw/driver/usb/usb.c
+++ b/src/hw/driver/usb/usb.c
@@ -9,6 +9,7 @@
 #include "usb.h"
 #include "cdc.h"
 #include "cli.h"
+#include "usb_mode.h"
 
 
 #ifdef _USE_HW_USB
@@ -127,6 +128,7 @@ bool usbBegin(UsbMode_t usb_mode)
     p_desc = &HID_Desc;
     logPrintf("[OK] usbBegin()\n");
     logPrintf("     USB_HID\r\n");
+    logPrintf("     USB_RATE \t: %s\r\n", usbModeGetName(usbModeGet()));  // [V250628R1] Report active polling mode.
     #endif
   }  
   else if (usb_mode == USB_CMP_MODE)
@@ -149,6 +151,7 @@ bool usbBegin(UsbMode_t usb_mode)
     p_desc = &CMP_Desc;
     logPrintf("[OK] usbBegin()\n");
     logPrintf("     USB_CMP\r\n");
+    logPrintf("     USB_RATE \t: %s\r\n", usbModeGetName(usbModeGet()));  // [V250628R1]
     #endif
   }  
   else

--- a/src/hw/driver/usb/usb_cmp/usbd_cmp.c
+++ b/src/hw/driver/usb/usb_cmp/usbd_cmp.c
@@ -33,6 +33,7 @@
   */
 
 #include "usbd_cmp.h"
+#include "usb_mode.h"
 
 
 #ifdef USE_USBD_COMPOSITE
@@ -858,10 +859,10 @@ static void  USBD_CMPSIT_HIDKeyboardDesc(USBD_HandleTypeDef *pdev, uint32_t pCon
 
   /* Append Endpoint descriptor to Configuration descriptor */
   __USBD_CMPSIT_SET_EP(pdev->tclasslist[pdev->classId].Eps[0].add,
-                       USBD_EP_TYPE_INTR, 
+                       USBD_EP_TYPE_INTR,
                        HID_EPIN_SIZE | (2<<11),
-                       HID_HS_BINTERVAL, 
-                       HID_FS_BINTERVAL);
+                       usbModeGetHsInterval(),
+                       usbModeGetFsInterval());  // [V250628R1]
 
 
   // VIA 
@@ -889,11 +890,11 @@ static void  USBD_CMPSIT_HIDKeyboardDesc(USBD_HandleTypeDef *pdev, uint32_t pCon
 
   /* Append Endpoint descriptor to Configuration descriptor */
   __USBD_CMPSIT_SET_EP(pdev->tclasslist[pdev->classId].Eps[1].add, USBD_EP_TYPE_INTR, HID_VIA_EP_SIZE, \
-                       4, HID_FS_BINTERVAL);
+                       usbModeGetHsInterval(), usbModeGetFsInterval());
 
   /* Append Endpoint descriptor to Configuration descriptor */
   __USBD_CMPSIT_SET_EP(pdev->tclasslist[pdev->classId].Eps[2].add, USBD_EP_TYPE_INTR, HID_VIA_EP_SIZE, \
-                       4, HID_FS_BINTERVAL);
+                       usbModeGetHsInterval(), usbModeGetFsInterval());
 
   /* Update Config Descriptor and IAD descriptor */
   ((USBD_ConfigDescTypeDef *)pConf)->bNumInterfaces += 2U;
@@ -925,7 +926,7 @@ static void  USBD_CMPSIT_HIDKeyboardDesc(USBD_HandleTypeDef *pdev, uint32_t pCon
 
   /* Append Endpoint descriptor to Configuration descriptor */
   __USBD_CMPSIT_SET_EP(pdev->tclasslist[pdev->classId].Eps[3].add, USBD_EP_TYPE_INTR, HID_EXK_EP_SIZE, \
-                       HID_HS_BINTERVAL, HID_FS_BINTERVAL);
+                       usbModeGetHsInterval(), usbModeGetFsInterval());
 
   /* Update Config Descriptor and IAD descriptor */
   ((USBD_ConfigDescTypeDef *)pConf)->bNumInterfaces += 1U;
@@ -965,7 +966,7 @@ static void  USBD_CMPSIT_HIDMouseDesc(USBD_HandleTypeDef *pdev, uint32_t pConf,
 
   /* Append Endpoint descriptor to Configuration descriptor */
   __USBD_CMPSIT_SET_EP(pdev->tclasslist[pdev->classId].Eps[0].add, USBD_EP_TYPE_INTR, HID_EPIN_SIZE, \
-                       HID_HS_BINTERVAL, HID_FS_BINTERVAL);
+                       usbModeGetHsInterval(), usbModeGetFsInterval());
 
   /* Update Config Descriptor and IAD descriptor */
   ((USBD_ConfigDescTypeDef *)pConf)->bNumInterfaces += 1U;

--- a/src/hw/driver/usb/usb_mode.c
+++ b/src/hw/driver/usb/usb_mode.c
@@ -1,0 +1,220 @@
+#include "usb_mode.h"
+
+#ifdef _USE_HW_USB
+
+#include <string.h>
+
+#include "cli.h"
+#include "eeprom.h"
+#include "log.h"
+#include "reset.h"
+
+#include "ap/modules/qmk/port/port.h"
+
+#define USB_MODE_DEFAULT USB_BOOTMODE_HS_8K
+
+static UsbBootMode_t boot_mode = USB_MODE_DEFAULT;
+static uint8_t       hs_interval = 1;
+static uint8_t       fs_interval = 1;
+
+static const char *usb_mode_names[USB_BOOTMODE_MAX] =
+  {
+    "HS-8K",
+    "HS-4K",
+    "HS-2K",
+    "FS-1K",
+  };
+
+// [V250628R1] Map boot mode to HID polling intervals.
+static void usbModeUpdateInterval(void)
+{
+  switch (boot_mode)
+  {
+    case USB_BOOTMODE_HS_8K:
+      hs_interval = 1;
+      fs_interval = 1;
+      break;
+
+    case USB_BOOTMODE_HS_4K:
+      hs_interval = 2;
+      fs_interval = 1;
+      break;
+
+    case USB_BOOTMODE_HS_2K:
+      hs_interval = 3;
+      fs_interval = 1;
+      break;
+
+    case USB_BOOTMODE_FS_1K:
+    default:
+      hs_interval = 1;
+      fs_interval = 1;
+      break;
+  }
+}
+
+static bool usbModeReadRaw(uint8_t *raw_mode)
+{
+  return eepromRead((uint32_t)EECONFIG_USER_BOOTMODE, raw_mode, 1);
+}
+
+static bool usbModeWriteRaw(uint8_t raw_mode)
+{
+  return eepromWrite((uint32_t)EECONFIG_USER_BOOTMODE, &raw_mode, 1);
+}
+
+static UsbBootMode_t usbModeSanitize(uint8_t raw_mode)
+{
+  if (raw_mode < USB_BOOTMODE_MAX)
+  {
+    return (UsbBootMode_t)raw_mode;
+  }
+  return USB_MODE_DEFAULT;
+}
+
+static void usbModeLogCurrent(void)
+{
+  logPrintf("[  ] USB BootMode : %s\n", usbModeGetName(boot_mode));
+}
+
+#ifdef _USE_HW_CLI
+static bool usbModeParseArg(const char *arg, UsbBootMode_t *mode)
+{
+  if (strcmp(arg, "8k") == 0)
+  {
+    *mode = USB_BOOTMODE_HS_8K;
+    return true;
+  }
+  if (strcmp(arg, "4k") == 0)
+  {
+    *mode = USB_BOOTMODE_HS_4K;
+    return true;
+  }
+  if (strcmp(arg, "2k") == 0)
+  {
+    *mode = USB_BOOTMODE_HS_2K;
+    return true;
+  }
+  if (strcmp(arg, "1k") == 0)
+  {
+    *mode = USB_BOOTMODE_FS_1K;
+    return true;
+  }
+  return false;
+}
+
+static void cliBoot(cli_args_t *args)
+{
+  bool ret = false;
+
+  if (args->argc == 1 && args->isStr(0, "info"))
+  {
+    cliPrintf("Boot mode : %s\n", usbModeGetName(boot_mode));
+    ret = true;
+  }
+
+  if (args->argc == 2 && args->isStr(0, "set"))
+  {
+    UsbBootMode_t mode;
+
+    if (usbModeParseArg(args->getStr(1), &mode))
+    {
+      cliPrintf("Apply boot mode : %s\n", usbModeGetName(mode));
+      if (!usbModeSaveAndReset(mode))
+      {
+        cliPrintf("Fail to update boot mode\n");
+      }
+    }
+    else
+    {
+      cliPrintf("Invalid mode. use 8k|4k|2k|1k\n");
+    }
+    ret = true;
+  }
+
+  if (!ret)
+  {
+    cliPrintf("boot info\n");
+    cliPrintf("boot set 8k\n");
+    cliPrintf("boot set 4k\n");
+    cliPrintf("boot set 2k\n");
+    cliPrintf("boot set 1k\n");
+  }
+}
+#endif
+
+bool usbModeInit(void)
+{
+  uint8_t raw_mode = (uint8_t)USB_MODE_DEFAULT;
+
+  if (!usbModeReadRaw(&raw_mode) || raw_mode >= USB_BOOTMODE_MAX)
+  {
+    raw_mode = (uint8_t)USB_MODE_DEFAULT;
+    // [V250628R1] Initialise EEPROM slot when empty or corrupted.
+    (void)usbModeWriteRaw(raw_mode);
+  }
+
+  boot_mode = usbModeSanitize(raw_mode);
+  usbModeUpdateInterval();
+  usbModeLogCurrent();
+
+#ifdef _USE_HW_CLI
+  cliAdd("boot", cliBoot);
+#endif
+
+  return true;
+}
+
+UsbBootMode_t usbModeGet(void)
+{
+  return boot_mode;
+}
+
+bool usbModeIsFs(void)
+{
+  return boot_mode == USB_BOOTMODE_FS_1K;
+}
+
+uint8_t usbModeGetHsInterval(void)
+{
+  return hs_interval;
+}
+
+uint8_t usbModeGetFsInterval(void)
+{
+  return fs_interval;
+}
+
+const char *usbModeGetName(UsbBootMode_t mode)
+{
+  if (mode < USB_BOOTMODE_MAX)
+  {
+    return usb_mode_names[mode];
+  }
+  return "UNKNOWN";
+}
+
+bool usbModeSaveAndReset(UsbBootMode_t mode)
+{
+  uint8_t raw_mode = (uint8_t)mode;
+
+  if (mode >= USB_BOOTMODE_MAX)
+  {
+    return false;
+  }
+
+  if (!usbModeWriteRaw(raw_mode))
+  {
+    return false;
+  }
+
+  boot_mode = usbModeSanitize(raw_mode);
+  usbModeUpdateInterval();
+
+  // [V250628R1] Reboot to apply the newly stored USB boot mode.
+  resetToReset();
+  return true;
+}
+
+#endif
+

--- a/src/hw/driver/usb/usb_mode.h
+++ b/src/hw/driver/usb/usb_mode.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "hw_def.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef _USE_HW_USB
+
+#include <stdbool.h>
+#include <stdint.h>
+
+// [V250628R1] Enumerates supported USB boot frequencies.
+typedef enum
+{
+  USB_BOOTMODE_HS_8K = 0,
+  USB_BOOTMODE_HS_4K,
+  USB_BOOTMODE_HS_2K,
+  USB_BOOTMODE_FS_1K,
+  USB_BOOTMODE_MAX
+} UsbBootMode_t;
+
+bool          usbModeInit(void);
+UsbBootMode_t usbModeGet(void);
+bool          usbModeIsFs(void);
+uint8_t       usbModeGetHsInterval(void);
+uint8_t       usbModeGetFsInterval(void);
+const char   *usbModeGetName(UsbBootMode_t mode);
+bool          usbModeSaveAndReset(UsbBootMode_t mode);
+
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+

--- a/src/hw/driver/usb/usbd_conf.c
+++ b/src/hw/driver/usb/usbd_conf.c
@@ -48,6 +48,7 @@
 #include "usbd_def.h"
 #include "usbd_core.h"
 #include "usbd_cdc.h"
+#include "usb_mode.h"
 
 
 PCD_HandleTypeDef hpcd_USB_OTG_HS;
@@ -199,13 +200,13 @@ void HAL_PCD_ResetCallback(PCD_HandleTypeDef *hpcd)
 {
   USBD_SpeedTypeDef speed = USBD_SPEED_FULL;
 
-  if ( hpcd->Init.speed == PCD_SPEED_HIGH)
+  if (hpcd->Init.speed == PCD_SPEED_HIGH)
   {
     speed = USBD_SPEED_HIGH;
   }
-  else if ( hpcd->Init.speed == PCD_SPEED_FULL)
+  else if (hpcd->Init.speed == PCD_SPEED_FULL || hpcd->Init.speed == PCD_SPEED_HIGH_IN_FULL)
   {
-    speed = USBD_SPEED_FULL;
+    speed = USBD_SPEED_FULL;  // [V250628R1] Treat HS-in-FS as full-speed for the device stack.
   }
   else
   {
@@ -344,7 +345,7 @@ USBD_StatusTypeDef USBD_LL_Init(USBD_HandleTypeDef *pdev)
 
   hpcd_USB_OTG_HS.Instance = USB_OTG_HS;
   hpcd_USB_OTG_HS.Init.dev_endpoints = 9;
-  hpcd_USB_OTG_HS.Init.speed = PCD_SPEED_HIGH;
+  hpcd_USB_OTG_HS.Init.speed = usbModeIsFs() ? PCD_SPEED_HIGH_IN_FULL : PCD_SPEED_HIGH;  // [V250628R1] Dynamically switch between HS and HS-in-FS.
   hpcd_USB_OTG_HS.Init.dma_enable = DISABLE;
   hpcd_USB_OTG_HS.Init.phy_itface = USB_OTG_HS_EMBEDDED_PHY;
   hpcd_USB_OTG_HS.Init.Sof_enable = ENABLE;

--- a/src/hw/hw.c
+++ b/src/hw/hw.c
@@ -1,4 +1,5 @@
 #include "hw.h"
+#include "usb_mode.h"
 
 
 
@@ -50,6 +51,7 @@ bool hwInit(void)
   resetInit();    
   i2cInit();
   eepromInit();
+  usbModeInit();  // [V250628R1] Load persisted USB polling configuration.
   #ifdef _USE_HW_QSPI
   qspiInit();
   #endif

--- a/src/hw/hw_def.h
+++ b/src/hw/hw_def.h
@@ -6,7 +6,7 @@
 #include QMK_KEYMAP_CONFIG_H
 
 
-#define _DEF_FIRMWATRE_VERSION      "V250627R1"
+#define _DEF_FIRMWATRE_VERSION      "V250628R1"
 #define _DEF_BOARD_NAME             "BARAM-QMK-H7S-FW"
 
 


### PR DESCRIPTION
## Summary
- add a USB boot mode helper that persists the selected polling rate and exposes `boot set` CLI helpers
- initialize the USB stack with the saved mode, including HS ↔ HS-in-FS switching and dynamic HID intervals
- log the active rate during startup and bump the firmware revision to V250628R1

## Testing
- cmake -S . -B build -DKEYBOARD_PATH='/keyboards/era/sirind/brick60'
- cmake --build build -j10

------
https://chatgpt.com/codex/tasks/task_e_68d2036e510c8332873d467488809e57