### PR TITLE
Add USB boot mode selection from EEPROM

### DIFF
--- a/src/ap/modules/qmk/port/port.h
+++ b/src/ap/modules/qmk/port/port.h
@@ -18,3 +18,4 @@
 #define EECONFIG_USER_KILL_SWITCH_LR  ((void *)((uint32_t)EECONFIG_USER_DATABLOCK +  8)) // 8B
 #define EECONFIG_USER_KILL_SWITCH_UD  ((void *)((uint32_t)EECONFIG_USER_DATABLOCK + 16)) // 8B
 #define EECONFIG_USER_KKUK            ((void *)((uint32_t)EECONFIG_USER_DATABLOCK + 24)) // 4B
+#define EECONFIG_USER_BOOTMODE        ((void *)((uint32_t)EECONFIG_USER_DATABLOCK + 28)) // 4B // V250923R1 Boot mode selection slot

--- a/src/hw/driver/usb/usb.h
+++ b/src/hw/driver/usb/usb.h
@@ -58,6 +58,21 @@ typedef enum UsbType
   USB_CON_HID = 4,
 } UsbType_t;
 
+typedef enum UsbBootMode                               // V250923R1 Persisted USB polling profile
+{
+  USB_BOOT_MODE_HS_8K = 0,
+  USB_BOOT_MODE_HS_4K,
+  USB_BOOT_MODE_HS_2K,
+  USB_BOOT_MODE_FS_1K,
+  USB_BOOT_MODE_MAX,
+} UsbBootMode_t;
+
+bool         usbBootModeLoad(void);                    // V250923R1 Load stored boot mode selection
+UsbBootMode_t usbBootModeGet(void);                    // V250923R1 Query active boot mode
+bool         usbBootModeIsFullSpeed(void);             // V250923R1 Check if FS (1 kHz) mode is requested
+uint8_t      usbBootModeGetHsInterval(void);           // V250923R1 Retrieve HS polling interval encoding
+bool         usbBootModeSaveAndReset(UsbBootMode_t mode);
+
 bool usbInit(void);
 bool usbBegin(UsbMode_t usb_mode);
 void usbDeInit(void);

--- a/src/hw/driver/usb/usb_cmp/usbd_cmp.c
+++ b/src/hw/driver/usb/usb_cmp/usbd_cmp.c
@@ -33,6 +33,7 @@
   */
 
 #include "usbd_cmp.h"
+#include "usb.h"                                      // V250923R1 Boot mode aware HID intervals
 
 
 #ifdef USE_USBD_COMPOSITE
@@ -858,9 +859,9 @@ static void  USBD_CMPSIT_HIDKeyboardDesc(USBD_HandleTypeDef *pdev, uint32_t pCon
 
   /* Append Endpoint descriptor to Configuration descriptor */
   __USBD_CMPSIT_SET_EP(pdev->tclasslist[pdev->classId].Eps[0].add,
-                       USBD_EP_TYPE_INTR, 
+                       USBD_EP_TYPE_INTR,
                        HID_EPIN_SIZE | (2<<11),
-                       HID_HS_BINTERVAL, 
+                       usbBootModeGetHsInterval(),
                        HID_FS_BINTERVAL);
 
 
@@ -889,11 +890,11 @@ static void  USBD_CMPSIT_HIDKeyboardDesc(USBD_HandleTypeDef *pdev, uint32_t pCon
 
   /* Append Endpoint descriptor to Configuration descriptor */
   __USBD_CMPSIT_SET_EP(pdev->tclasslist[pdev->classId].Eps[1].add, USBD_EP_TYPE_INTR, HID_VIA_EP_SIZE, \
-                       4, HID_FS_BINTERVAL);
+                       usbBootModeGetHsInterval(), HID_FS_BINTERVAL);
 
   /* Append Endpoint descriptor to Configuration descriptor */
   __USBD_CMPSIT_SET_EP(pdev->tclasslist[pdev->classId].Eps[2].add, USBD_EP_TYPE_INTR, HID_VIA_EP_SIZE, \
-                       4, HID_FS_BINTERVAL);
+                       usbBootModeGetHsInterval(), HID_FS_BINTERVAL);
 
   /* Update Config Descriptor and IAD descriptor */
   ((USBD_ConfigDescTypeDef *)pConf)->bNumInterfaces += 2U;
@@ -925,7 +926,7 @@ static void  USBD_CMPSIT_HIDKeyboardDesc(USBD_HandleTypeDef *pdev, uint32_t pCon
 
   /* Append Endpoint descriptor to Configuration descriptor */
   __USBD_CMPSIT_SET_EP(pdev->tclasslist[pdev->classId].Eps[3].add, USBD_EP_TYPE_INTR, HID_EXK_EP_SIZE, \
-                       HID_HS_BINTERVAL, HID_FS_BINTERVAL);
+                       usbBootModeGetHsInterval(), HID_FS_BINTERVAL);
 
   /* Update Config Descriptor and IAD descriptor */
   ((USBD_ConfigDescTypeDef *)pConf)->bNumInterfaces += 1U;

--- a/src/hw/driver/usb/usbd_conf.c
+++ b/src/hw/driver/usb/usbd_conf.c
@@ -203,6 +203,10 @@ void HAL_PCD_ResetCallback(PCD_HandleTypeDef *hpcd)
   {
     speed = USBD_SPEED_HIGH;
   }
+  else if ( hpcd->Init.speed == PCD_SPEED_HIGH_IN_FULL)
+  {
+    speed = USBD_SPEED_FULL;                                      // V250923R1 HS core running in FS mode
+  }
   else if ( hpcd->Init.speed == PCD_SPEED_FULL)
   {
     speed = USBD_SPEED_FULL;
@@ -344,7 +348,14 @@ USBD_StatusTypeDef USBD_LL_Init(USBD_HandleTypeDef *pdev)
 
   hpcd_USB_OTG_HS.Instance = USB_OTG_HS;
   hpcd_USB_OTG_HS.Init.dev_endpoints = 9;
-  hpcd_USB_OTG_HS.Init.speed = PCD_SPEED_HIGH;
+  if (usbBootModeIsFullSpeed() == true)
+  {
+    hpcd_USB_OTG_HS.Init.speed = PCD_SPEED_HIGH_IN_FULL;          // V250923R1 HS PHY operating at FS 1 kHz
+  }
+  else
+  {
+    hpcd_USB_OTG_HS.Init.speed = PCD_SPEED_HIGH;
+  }
   hpcd_USB_OTG_HS.Init.dma_enable = DISABLE;
   hpcd_USB_OTG_HS.Init.phy_itface = USB_OTG_HS_EMBEDDED_PHY;
   hpcd_USB_OTG_HS.Init.Sof_enable = ENABLE;

--- a/src/hw/hw.c
+++ b/src/hw/hw.c
@@ -1,4 +1,5 @@
 #include "hw.h"
+#include "qmk/port/platforms/eeprom.h"  // V250923R1 Preload QMK EEPROM services
 
 
 
@@ -50,6 +51,11 @@ bool hwInit(void)
   resetInit();    
   i2cInit();
   eepromInit();
+  eeprom_init();                                              // V250923R1 Sync QMK EEPROM image before USB init
+  if (usbBootModeLoad() != true)                              // V250923R1 Apply stored USB boot mode preference
+  {
+    logPrintf("[!] usbBootModeLoad Fail\n");
+  }
   #ifdef _USE_HW_QSPI
   qspiInit();
   #endif

--- a/src/hw/hw_def.h
+++ b/src/hw/hw_def.h
@@ -6,7 +6,7 @@
 #include QMK_KEYMAP_CONFIG_H
 
 
-#define _DEF_FIRMWATRE_VERSION      "V250627R1"
+#define _DEF_FIRMWATRE_VERSION      "V250923R1"
 #define _DEF_BOARD_NAME             "BARAM-QMK-H7S-FW"
 
 


### PR DESCRIPTION
## Summary
- add a dedicated EECONFIG slot for persisting the USB boot mode and expose helpers/CLI commands to read or update it
- initialise the hardware USB stack using the persisted mode, including HS/FS speed selection and dynamic HID polling intervals
- load the boot mode early during hardware init and bump the firmware version tag

## Testing
- cmake -S . -B build -DKEYBOARD_PATH='/keyboards/era/sirind/brick60'
- cmake --build build -j10

------
https://chatgpt.com/codex/tasks/task_e_68d2036e510c8332873d467488809e57