### PR TITLE
Fix FS HID descriptor wMaxPacket handling

### DIFF
--- a/src/hw/driver/usb/usb_cmp/usbd_cmp.c
+++ b/src/hw/driver/usb/usb_cmp/usbd_cmp.c
@@ -858,9 +858,14 @@ static void  USBD_CMPSIT_HIDKeyboardDesc(USBD_HandleTypeDef *pdev, uint32_t pCon
   *Sze                                 += (uint32_t)sizeof(USBD_HIDDescTypeDef);
 
   /* Append Endpoint descriptor to Configuration descriptor */
+  uint16_t hid_keyboard_mps = HID_EPIN_SIZE;                              // V250923R2 FS 모드에서 64바이트 패킷 유지
+  if (speed == (uint8_t)USBD_SPEED_HIGH)
+  {
+    hid_keyboard_mps |= (2U << 11);                                       // V250923R2 HS 모드에서는 3트랜잭션 유지
+  }
   __USBD_CMPSIT_SET_EP(pdev->tclasslist[pdev->classId].Eps[0].add,
                        USBD_EP_TYPE_INTR,
-                       HID_EPIN_SIZE | (2<<11),
+                       hid_keyboard_mps,
                        usbBootModeGetHsInterval(),
                        HID_FS_BINTERVAL);
 

--- a/src/hw/hw_def.h
+++ b/src/hw/hw_def.h
@@ -6,7 +6,7 @@
 #include QMK_KEYMAP_CONFIG_H
 
 
-#define _DEF_FIRMWATRE_VERSION      "V250923R1"
+#define _DEF_FIRMWATRE_VERSION      "V250923R2"  // V250923R2 FS descriptor wMaxPacket 정합 수정
 #define _DEF_BOARD_NAME             "BARAM-QMK-H7S-FW"
 
 


### PR DESCRIPTION
## Summary
- HID 키보드 엔드포인트의 FS wMaxPacket 값을 64바이트로 유지하도록 수정해 FS-1K 연결 인식 실패를 해결했습니다.
- 펌웨어 버전을 V250923R2로 갱신했습니다.

## Testing
- cmake -S . -B build -DKEYBOARD_PATH='/keyboards/era/sirind/brick60'
- cmake --build build -j10

------
https://chatgpt.com/codex/tasks/task_e_68d377a559c883328647e064c6075762