### PR TITLE
Fix FS matrix info reporting delay

### DIFF
--- a/src/hw/driver/usb/usb_hid/usbd_hid.c
+++ b/src/hw/driver/usb/usb_hid/usbd_hid.c
@@ -1149,24 +1149,25 @@ bool usbHidSendReportEXK(uint8_t *p_data, uint16_t length)
 
 void usbHidMeasurePollRate(void)
 {
-  static uint32_t cnt = 0; 
+  static uint32_t cnt = 0;
+  uint32_t        sample_window = usbBootModeIsFullSpeed() ? 1000U : 8000U; // V250924R1 Align poll window with active USB speed
 
 
   rate_time_sof_pre = micros();
-  if (cnt >= 8000)
+  if (cnt >= sample_window)
   {
     cnt = 0;
     data_in_rate = data_in_cnt;
-    rate_time_min = rate_time_min_check; 
-    rate_time_max = rate_time_max_check;     
+    rate_time_min = rate_time_min_check;
+    rate_time_max = rate_time_max_check;
     rate_time_avg = rate_time_sum / (data_in_cnt + 1);
     data_in_cnt = 0;
 
-    rate_time_min_check = 0xFFFF; 
-    rate_time_max_check = 0;     
+    rate_time_min_check = 0xFFFF;
+    rate_time_max_check = 0;
     rate_time_sum = 0;
-  }  
-  cnt++;  
+  }
+  cnt++;
 }
 
 void usbHidMeasureRateTime(void)

--- a/src/hw/hw_def.h
+++ b/src/hw/hw_def.h
@@ -6,7 +6,7 @@
 #include QMK_KEYMAP_CONFIG_H
 
 
-#define _DEF_FIRMWATRE_VERSION      "V250923R2"  // V250923R2 FS descriptor wMaxPacket 정합 수정
+#define _DEF_FIRMWATRE_VERSION      "V250924R1"  // V250924R1 FS matrix info poll latency 수정
 #define _DEF_BOARD_NAME             "BARAM-QMK-H7S-FW"
 
 


### PR DESCRIPTION
## Summary
- align the HID poll rate measurement window with the active USB speed so Full-Speed mode updates matrix info without multi-second lag
- bump `_DEF_FIRMWATRE_VERSION` to `V250924R1`

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d38793f190833292211681e2403121