### PR TITLE
Update README with USB roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,10 @@ PROJECT_CONTEXT
 - TARGET_MCU: STM32H7S series
 - USB_PHY_MODE: internal High-speed PHY only
 - BASE_REPORT_RATE_OBJECTIVE: 8000Hz interrupt-driven input at High-speed
+- STATUS_EXTENDED_REPORT_RATES: High-speed 4000Hz + High-speed 2000Hz + Full-speed 1000Hz implemented
 - ACTIVE_WORK_ITEMS:
-  - EXTENDED_REPORT_RATES: add High-speed 4000Hz, High-speed 2000Hz, Full-speed 1000Hz support
+  - USB_INSTABILITY_DETECTOR: implement microframe loss/delay detection logic
+  - POLLING_RATE_DOWNGRADE: downgrade report rate when instability is detected
 - QMK_PORT_SUMMARY: QMK logic ported and tuned for high-bandwidth USB keyboard firmware
 
 CODEX_RULES


### PR DESCRIPTION
## Summary
- note that the extended report rates feature for high-speed 4K/2K and full-speed 1K is complete
- describe new active work items for USB instability detection and polling-rate downgrade logic

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68d3ad2ac8448332bcde5d6ac2f934ba