### PR TITLE
Implement USB instability detection and auto downgrade

### DIFF
--- a/src/ap/ap.c
+++ b/src/ap/ap.c
@@ -33,6 +33,7 @@ void apMain(void)
     }
 
     cliUpdate();
+    usbProcess();                                               // V250924R2 USB 안정성 이벤트 처리
     qmkUpdate();
   }
 }

--- a/src/hw/driver/usb/usb.h
+++ b/src/hw/driver/usb/usb.h
@@ -72,6 +72,8 @@ UsbBootMode_t usbBootModeGet(void);                    // V250923R1 Query active
 bool         usbBootModeIsFullSpeed(void);             // V250923R1 Check if FS (1 kHz) mode is requested
 uint8_t      usbBootModeGetHsInterval(void);           // V250923R1 Retrieve HS polling interval encoding
 bool         usbBootModeSaveAndReset(UsbBootMode_t mode);
+bool         usbRequestBootModeDowngrade(UsbBootMode_t mode, uint32_t measured_delta_us, uint32_t expected_us); // V250924R2 USB 다운그레이드 요청 인터페이스
+void         usbProcess(void);                         // V250924R2 USB 안정성 모니터 서비스 루프
 
 bool usbInit(void);
 bool usbBegin(UsbMode_t usb_mode);

--- a/src/hw/hw_def.h
+++ b/src/hw/hw_def.h
@@ -6,7 +6,7 @@
 #include QMK_KEYMAP_CONFIG_H
 
 
-#define _DEF_FIRMWATRE_VERSION      "V250924R1"  // V250924R1 FS matrix info poll latency 수정
+#define _DEF_FIRMWATRE_VERSION      "V250924R2"  // V250924R2 USB 안정성 모니터링 및 자동 다운그레이드
 #define _DEF_BOARD_NAME             "BARAM-QMK-H7S-FW"
 
 


### PR DESCRIPTION
## Summary
- add a SOF/uSOF monitoring state machine that tracks missed microframes and requests a polling-rate downgrade when instability persists
- add a deferred USB boot mode downgrade handler that logs the event and saves the new mode before resetting
- expose the downgrade service through the main loop and bump the firmware version to V250924R2

## Testing
- `cmake -S . -B build -DKEYBOARD_PATH='/keyboards/era/sirind/brick60'`
- `cmake --build build -j10`


------
https://chatgpt.com/codex/tasks/task_e_68d3ccf5a7808332bce2ab43dae6b55f