### PR TITLE
Refine USB SOF warmup guard and reduce monitor overhead

### DIFF
--- a/src/hw/driver/usb/usb.h
+++ b/src/hw/driver/usb/usb.h
@@ -67,12 +67,24 @@ typedef enum UsbBootMode                               // V250923R1 Persisted US
   USB_BOOT_MODE_MAX,
 } UsbBootMode_t;
 
+#define USB_BOOT_MONITOR_CONFIRM_DELAY_MS (2000U)
+
+typedef enum
+{
+  USB_BOOT_DOWNGRADE_REJECTED = 0,
+  USB_BOOT_DOWNGRADE_ARMED,
+  USB_BOOT_DOWNGRADE_CONFIRMED,
+} usb_boot_downgrade_result_t;
+
 bool         usbBootModeLoad(void);                    // V250923R1 Load stored boot mode selection
 UsbBootMode_t usbBootModeGet(void);                    // V250923R1 Query active boot mode
 bool         usbBootModeIsFullSpeed(void);             // V250923R1 Check if FS (1 kHz) mode is requested
 uint8_t      usbBootModeGetHsInterval(void);           // V250923R1 Retrieve HS polling interval encoding
 bool         usbBootModeSaveAndReset(UsbBootMode_t mode);
-bool         usbRequestBootModeDowngrade(UsbBootMode_t mode, uint32_t measured_delta_us, uint32_t expected_us); // V250924R2 USB 다운그레이드 요청 인터페이스
+usb_boot_downgrade_result_t usbRequestBootModeDowngrade(UsbBootMode_t mode,
+                                                        uint32_t      measured_delta_us,
+                                                        uint32_t      expected_us,
+                                                        uint32_t      now_ms); // V250924R2 USB 다운그레이드 요청 인터페이스
 void         usbProcess(void);                         // V250924R2 USB 안정성 모니터 서비스 루프
 
 bool usbInit(void);

--- a/src/hw/hw_def.h
+++ b/src/hw/hw_def.h
@@ -6,7 +6,7 @@
 #include QMK_KEYMAP_CONFIG_H
 
 
-#define _DEF_FIRMWATRE_VERSION      "V250924R2"  // V250924R2 USB 안정성 모니터링 및 자동 다운그레이드
+#define _DEF_FIRMWATRE_VERSION      "V250924R3"  // V250924R3 USB 안정성 모니터링 워밍업 가드 최적화
 #define _DEF_BOARD_NAME             "BARAM-QMK-H7S-FW"
 
 


### PR DESCRIPTION
## Summary
- extend the SOF monitor with a warm-up frame counter and timeout so start-up jitter is ignored until the bus has shown sustained stability
- reset warm-up bookkeeping across configuration/suspend changes and fast-return from the USB service loop when no downgrade is pending to avoid unnecessary work
- bump the firmware revision tag to V250924R3 for the updated monitor behaviour

## Testing
- not run (firmware build not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d40064b28883328cffdf5af0bafbf5