### PR TITLE
USB 초기 열거 타임아웃 감시 보강 및 로그 영문화 (V251001R5)

### DIFF
--- a/docs/dev_monitor_codex_reference.md
+++ b/docs/dev_monitor_codex_reference.md
@@ -10,11 +10,11 @@
 | --- | --- | --- |
 | `src/ap/modules/qmk/port/port.h` | `EECONFIG_USER_BOOTMODE` | BootMode 선택값을 사용자 EEPROM에 저장할 슬롯을 예약합니다.
 | `src/hw/hw.c` | `usbBootModeLoad()` | 부팅 직후 저장된 BootMode를 로드해 SOF 모니터 및 큐가 올바른 초기 상태로 시작하게 합니다.
-| `src/hw/driver/usb/usb.[ch]` | `usbRequestBootModeDowngrade`, `usbProcess()`, `cliBoot` | 다운그레이드 요청 큐 상태 머신(ARMED/COMMIT), 로그, CLI 명령, 재부팅 루틴을 제공합니다.
+| `src/hw/driver/usb/usb.[ch]` | `usbRequestBootModeDowngrade`, `usbProcess()`, `cliBoot` | 다운그레이드 요청 큐 상태 머신(ARMED/COMMIT), 초기 열거 타임아웃 감시, 로그, CLI 명령, 재부팅 루틴을 제공합니다.
 | `src/hw/driver/usb/usb_hid/usbd_hid.c` | `usbHidMonitorSof()`, `usbHidSofMonitorApplySpeedParams()` | 마이크로프레임 간격 기반 점수 계산, 워밍업/홀드오프/감쇠 정책, 속도별 파라미터 캐싱을 담당합니다.
 | `src/hw/driver/usb/usb_cmp/usbd_cmp.c` | HS/FS `bInterval` 유지 | 다운그레이드 시에도 안정적인 패킷 크기를 보장합니다.
 | `src/hw/driver/usb/usbd_conf.c` | `usbBootModeIsFullSpeed()` 분기 | HS PHY에서 FS 1kHz 강제 모드를 선택할 수 있습니다.
-| `src/hw/hw_def.h` | `_DEF_FIRMWATRE_VERSION` | 모니터 기능 릴리스를 `V250924R4`까지 태깅합니다.
+| `src/hw/hw_def.h` | `_DEF_FIRMWATRE_VERSION` | 모니터 기능 릴리스를 `V251001R5`까지 태깅합니다.
 | `src/ap/ap.c` | `usbProcess()` 호출 | 메인 루프에서 큐 상태 머신을 주기적으로 서비스합니다.
 
 ## 3. 상태 머신 & 데이터 구조 스냅샷
@@ -27,10 +27,10 @@
   4. **임계 도달**: `degrade_threshold` 이상이면 다음 단계 부트 모드를 산출하고 큐에 다운그레이드를 요청합니다.
 
 ### 3.2 다운그레이드 큐(`usb_boot_mode_request_t`)
-- 필드 핵심: `stage`(IDLE→ARMED→COMMIT), `next_mode`, `delta_us`, `expected_us`, `ready_ms`, `timeout_ms`, `log_pending`.
+- 필드 핵심: `stage`(IDLE→ARMED→COMMIT), `next_mode`, `delta_us`, `expected_us`, `ready_ms`, `timeout_ms`, `log_pending`, `reason`.
 - `ARMED` 단계에서 첫 로그를 출력하고 2초 확인 지연(`USB_BOOT_MONITOR_CONFIRM_DELAY_MS`)을 기다립니다.
-- 확인 지연이 경과하면 `COMMIT`으로 승격되어 저장/리셋을 수행하고, 실패 시 `[!] USB Poll 모드 저장 실패` 로그 후 큐를 초기화합니다.
-- `usbProcess()`는 IDLE 상태에서 반환하여 메인 루프 오버헤드를 최소화합니다.
+- 확인 지연이 경과하면 `COMMIT`으로 승격되어 저장/리셋을 수행하고, 실패 시 `[NG] USB poll mode store failed` 로그 후 큐를 초기화합니다.
+- `usbProcess()`는 IDLE 상태에서 반환하여 메인 루프 오버헤드를 최소화하며, 별도로 초기 열거 타임아웃 감시를 수행합니다.
 
 ## 4. 속도별 파라미터 레퍼런스
 | USB 속도 | `expected_us` | `stable_threshold_us` | `decay_interval_us` | `degrade_threshold` | 워밍업 프레임 |
@@ -55,7 +55,7 @@
 
 ### V250924R2 — SOF 감시 & 다운그레이드 큐 도입
 - `usbHidMonitorSof()`가 SOF 간격을 계측하고 누락된 마이크로프레임 수에 따라 점수를 가산합니다.
-- `usbHidResolveDowngradeTarget()`과 `usbRequestBootModeDowngrade()`로 단계적 모드 하향과 ARM/COMMIT 단계 큐를 구성합니다.
+- `usbBootModeGetNextLower()`와 `usbRequestBootModeDowngrade()`로 단계적 모드 하향과 ARM/COMMIT 단계 큐를 구성합니다.
 - `usbProcess()`와 `ap.c` 메인 루프가 큐를 서비스하며, 로그와 타임아웃 관리를 처리합니다.
 
 ### V250924R3 — 워밍업/홀드오프 기반 안정화
@@ -67,9 +67,14 @@
 - 속도 변경·재개 시 캐시와 워밍업 타이머를 갱신하여 다운그레이드 판단의 일관성을 높입니다.
 - `_DEF_FIRMWATRE_VERSION`이 `V250924R4`로 갱신되어 모니터 최적화를 식별합니다.
 
+### V251001R5 — 초기 열거 타임아웃 & 로그 영문화
+- `usbProcess()`가 USB 초기 열거 타임아웃을 감지해 다운그레이드 큐에 `enumeration timeout` 사유를 기록합니다.
+- `usb_boot_mode_request_t`에 `reason` 필드를 추가해 SOF 지터/열거 타임아웃을 구분하고, 관련 로그를 영문화(`[NG] USB poll instability detected`, `[NG] USB enumeration timeout detected`)했습니다.
+- `_DEF_FIRMWATRE_VERSION`을 `V251001R5`로 올려 초기 연결 감시 강화를 식별합니다.
+
 ## 6. CODEX 점검 팁
 - SOF 모니터 파라미터를 수정할 때는 `USB_BOOT_MONITOR_CONFIRM_DELAY_MS`와 `USB_SOF_MONITOR_*` 상수의 상호 의존성을 반드시 검토하십시오.
-- 다운그레이드 큐는 리셋을 동반하므로, 신규 모드 추가 시 `usbHidResolveDowngradeTarget()`과 `usb_boot_mode_request_t` 초기화 경로를 함께 업데이트해야 합니다.
+- 다운그레이드 큐는 리셋을 동반하므로, 신규 모드 추가 시 `usbBootModeGetNextLower()`와 `usb_boot_mode_request_t` 초기화 경로를 함께 업데이트해야 합니다.
 - `usbProcess()`는 IDLE 상태에서 즉시 반환하도록 설계되어 있으므로, 추가 로직을 삽입할 때 조기 반환 조건을 유지하여 메인 루프 부하를 최소화하십시오.
 - CLI 확장 시 `log_pending` 플래그가 중복 로그를 방지하므로, 새로운 로그 포인트를 넣을 때는 해당 플래그 흐름을 참고하세요.
 

--- a/src/hw/driver/usb/usb.h
+++ b/src/hw/driver/usb/usb.h
@@ -71,6 +71,12 @@ typedef enum UsbBootMode                               // V250923R1 Persisted US
 
 typedef enum
 {
+  USB_BOOT_MONITOR_REASON_SOF_JITTER = 0,      // V251001R5: SOF 지터 기반 불안정 감지
+  USB_BOOT_MONITOR_REASON_ENUM_TIMEOUT,        // V251001R5: USB 초기화/열거 타임아웃 감지
+} usb_boot_monitor_reason_t;
+
+typedef enum
+{
   USB_BOOT_DOWNGRADE_REJECTED = 0,
   USB_BOOT_DOWNGRADE_ARMED,
   USB_BOOT_DOWNGRADE_CONFIRMED,
@@ -80,11 +86,13 @@ bool         usbBootModeLoad(void);                    // V250923R1 Load stored 
 UsbBootMode_t usbBootModeGet(void);                    // V250923R1 Query active boot mode
 bool         usbBootModeIsFullSpeed(void);             // V250923R1 Check if FS (1 kHz) mode is requested
 uint8_t      usbBootModeGetHsInterval(void);           // V250923R1 Retrieve HS polling interval encoding
+UsbBootMode_t usbBootModeGetNextLower(UsbBootMode_t mode); // V251001R5: 단계적 폴링 모드 하향 계산
 bool         usbBootModeSaveAndReset(UsbBootMode_t mode);
 usb_boot_downgrade_result_t usbRequestBootModeDowngrade(UsbBootMode_t mode,
                                                         uint32_t      measured_delta_us,
                                                         uint32_t      expected_us,
-                                                        uint32_t      now_ms); // V250924R2 USB 다운그레이드 요청 인터페이스
+                                                        uint32_t      now_ms,
+                                                        usb_boot_monitor_reason_t reason); // V251001R5: 감지 사유 전달
 void         usbProcess(void);                         // V250924R2 USB 안정성 모니터 서비스 루프
 
 bool usbInit(void);

--- a/src/hw/hw_def.h
+++ b/src/hw/hw_def.h
@@ -6,7 +6,7 @@
 #include QMK_KEYMAP_CONFIG_H
 
 
-#define _DEF_FIRMWATRE_VERSION      "V251001R4"  // V251001R4: 고스트 판정용 행 캐시로 키맵 필터 재계산 최소화
+#define _DEF_FIRMWATRE_VERSION      "V251001R5"  // V251001R5: USB 불안정 탐지에 초기 연결 타임아웃 보강 및 로그 영문화
 #define _DEF_BOARD_NAME             "BARAM-QMK-H7S-FW"
 
 


### PR DESCRIPTION
## 요약
- USB 다운그레이드 큐에 감지 사유 필드와 영문화된 로그를 추가해 SOF 지터와 열거 타임아웃을 구분했습니다.
- USB 초기 연결이 장시간 IDLE에 머무를 때 자동으로 하위 폴링 모드를 준비하도록 열거 타임아웃 감시를 도입했습니다.
- HID 모듈이 공용 폴링 모드 하향 계산을 사용하도록 정리하고, 개발 문서를 V251001R5 기준으로 업데이트했습니다.

## 테스트
- (수행하지 않음)


------
https://chatgpt.com/codex/tasks/task_e_68ddcd237ac0833293c1cc2331717acb