### PR TITLE
USB SOF 모니터 파라미터 테이블화 및 홀드오프 최적화

### DIFF
--- a/src/hw/hw_def.h
+++ b/src/hw/hw_def.h
@@ -6,7 +6,7 @@
 #include QMK_KEYMAP_CONFIG_H
 
 
-#define _DEF_FIRMWATRE_VERSION      "V251001R7"  // V251001R7: SOF 모니터 타임스탬프 래핑 대응 및 점수 계산 정리
+#define _DEF_FIRMWATRE_VERSION      "V251002R2"  // V251002R2: 홀드오프 타임스탬프 리셋 보강
 #define _DEF_BOARD_NAME             "BARAM-QMK-H7S-FW"
 
 


### PR DESCRIPTION
## 요약
- USB SOF 모니터 속도별 파라미터를 테이블화하여 유지보수를 단순화했습니다.
- 홀드오프 구간을 조기 반환하도록 유지하면서 속도 전환 시 타임스탬프를 즉시 리셋해 재정렬 과정에서의 오동작 가능성을 줄였습니다.
- 펌웨어 버전 문자열을 V251002R2로 갱신했습니다.

## 테스트
- 테스트를 실행하지 않았습니다.


------
https://chatgpt.com/codex/tasks/task_e_68df1d646748833283f5d9017fa9b12b