### PR TITLE
V251008R8: SOF 모니터 점수 기준을 R6 수준으로 회귀

### DIFF
--- a/src/hw/driver/usb/usb_hid/usbd_hid.c
+++ b/src/hw/driver/usb/usb_hid/usbd_hid.c
@@ -489,7 +489,7 @@ enum
   USB_SOF_MONITOR_WARMUP_TIMEOUT_MS = USB_SOF_MONITOR_CONFIG_HOLDOFF_MS + USB_BOOT_MONITOR_CONFIRM_DELAY_MS, // V250924R3 워밍업 최대 시간(ms)
   USB_SOF_MONITOR_WARMUP_FRAMES_HS  = 2048U,                                             // V250924R3 HS 안정성 확인 프레임 수
   USB_SOF_MONITOR_WARMUP_FRAMES_FS  = 128U,                                              // V250924R3 FS 안정성 확인 프레임 수
-  USB_SOF_MONITOR_SCORE_CAP         = 7U,                                                // V251005R4 대규모 SOF 누락 가중치 확장
+  USB_SOF_MONITOR_SCORE_CAP         = 3U,                                                // V251008R8 테스트용으로 V251001R6 점수 상한 복귀
   USB_SOF_MONITOR_CONFIG_HOLDOFF_US = USB_SOF_MONITOR_CONFIG_HOLDOFF_MS * 1000UL,        // 구성 직후 워밍업 지연(us)
   USB_SOF_MONITOR_WARMUP_TIMEOUT_US = USB_SOF_MONITOR_WARMUP_TIMEOUT_MS * 1000UL,        // 워밍업 최대 시간(us)
   USB_SOF_MONITOR_RESUME_HOLDOFF_US = 200U * 1000UL,                                      // 일시중지 해제 후 홀드오프(us)
@@ -1560,34 +1560,23 @@ static void usbHidMonitorSof(uint32_t now_us)
     uint32_t missed_frames = usbCalcMissedFrames((uint32_t)expected_us,
                                                  delta_us);         // V251005R6 속도별 상수 나눗셈으로 누락 프레임 산출
                                                                     // V251007R9 안정 임계 ≥ 2×기대 간격이어서 최소 1프레임 보장
-    uint8_t  penalty       = (missed_frames <= (USB_SOF_MONITOR_SCORE_CAP + 1U))
-                               ? (uint8_t)(missed_frames - 1U)
-                               : USB_SOF_MONITOR_SCORE_CAP;        // V251008R3 상수 비교로 8비트 패널티 즉시 산출 (V251005R5 8비트 산술 유지)
+    uint32_t penalty       = (missed_frames > 0U) ? (missed_frames - 1U)
+                                                  : 0U;            // V251008R8 테스트 복귀: 누락 프레임 기반 점수 계산
 
-    uint8_t degrade_threshold = mon->degrade_threshold;            // V251003R7 임계 파라미터 접근 지연으로 ISR 경량화
-    bool    downgrade_trigger = (score >= degrade_threshold);      // V251008R2 기존 점수만으로 임계 초과 여부 선행 판단
-
-    if (!downgrade_trigger && penalty != 0U)                       // V251008R2 패널티가 있을 때만 누적 연산 실행
+    if (penalty > USB_SOF_MONITOR_SCORE_CAP)
     {
-      uint8_t room = (uint8_t)(degrade_threshold - score);         // V251008R2 임계까지 남은 점수 여유 계산
-
-      if (penalty >= room)
-      {
-        score             = degrade_threshold;                     // V251008R2 임계 도달 시 점수를 포화해 후속 비교 제거
-        downgrade_trigger = true;
-      }
-      else
-      {
-        score = (uint8_t)(score + penalty);                        // V251008R2 임계 미도달 시 패널티만 누적
-      }
+      penalty = USB_SOF_MONITOR_SCORE_CAP;                          // V251008R8 테스트 복귀: 단일 이벤트 점수 상한 유지
     }
 
-    if (downgrade_trigger)                                         // V251008R2 포화 이후에도 동일 조건으로 다운그레이드 유지
+    uint8_t  degrade_threshold = mon->degrade_threshold;            // V251003R7 임계 파라미터 접근 지연으로 ISR 경량화
+    uint32_t accumulated       = (uint32_t)score + penalty;         // V251008R8 테스트 복귀: 누적 점수 기반 임계 비교
+
+    if (accumulated >= (uint32_t)degrade_threshold)                 // V251008R8 테스트 복귀: 임계 초과 시에만 다운그레이드 실행
     {
       UsbBootMode_t next_mode = usbHidResolveDowngradeTarget();
       uint32_t      holdoff   = USB_SOF_MONITOR_RECOVERY_DELAY_US; // V251003R1 홀드오프 연장 경로 통합
 
-      if (next_mode < USB_BOOT_MODE_MAX)                           // V251008R3 다운그레이드 대상이 있을 때만 보고값 산출·큐 요청
+      if (next_mode < USB_BOOT_MODE_MAX)                           // V251008R3 다운그레드 대상이 있을 때만 보고값 산출·큐 요청
       {
         uint16_t missed_frames_report = (missed_frames > UINT16_MAX) ? UINT16_MAX
                                                                   : (uint16_t)missed_frames; // V251006R2 다운그레이드 시에만 누락 프레임 포화 변환
@@ -1611,7 +1600,7 @@ static void usbHidMonitorSof(uint32_t now_us)
     }
     else
     {
-      // no-op: score가 8비트 누적으로 이미 갱신됨               // V251005R8 단일 비교 경로에서는 추가 처리 불필요
+      score = (uint8_t)accumulated;                                // V251008R8 테스트 복귀: 임계 미도달 시 누적 점수만 갱신
     }
   }
 

--- a/src/hw/hw_def.h
+++ b/src/hw/hw_def.h
@@ -6,7 +6,7 @@
 #include QMK_KEYMAP_CONFIG_H
 
 
-#define _DEF_FIRMWATRE_VERSION      "V251008R8"  // V251008R8: LED 상태 경로 비동기화 및 EP0 홀드오프 제거 재검토
+#define _DEF_FIRMWATRE_VERSION      "V251008R8"  // V251008R8: USB SOF 점수 상한을 테스트용으로 V251001R6 수준으로 복귀
 #define _DEF_BOARD_NAME             "BARAM-QMK-H7S-FW"
 
 


### PR DESCRIPTION
## 요약
- SOF 모니터 점수 상한을 3점으로 되돌려 V251001R6과 동일한 단일 이벤트 누적 한계를 복원했습니다.
- 누락 프레임 누적 로직을 기존 합산 기반으로 되돌려 다운그레이드 임계 도달 조건을 이전 버전과 동일하게 유지했습니다.
- 펌웨어 버전 주석을 이번 테스트 목적 변경 사항에 맞추어 갱신했습니다.

## 테스트
- (수행하지 않음)

현재 펌웨어 버전: V251008R8


------
https://chatgpt.com/codex/tasks/task_e_68e26d45230c83328e63f3fb8082dcd5