### PR TITLE
Caps Lock LED SET_REPORT 비동기화 및 펌웨어 버전 V251008R8 반영

### DIFF
--- a/src/ap/modules/qmk/keyboards/era/sirind/brick60/port/led_port.c
+++ b/src/ap/modules/qmk/keyboards/era/sirind/brick60/port/led_port.c
@@ -37,15 +37,20 @@ static void via_qmk_led_save(uint8_t led_type);
 
 // static led_t leds_temp_for_via = {0};
 static led_config_t led_config[LED_TYPE_MAX_CH];
+static volatile led_t host_led_state = {0};  // V251008R8 Caps Lock SET_REPORT 시 LED 갱신을 지연 적용해 USB SOF 공백 방지
 
 
 EECONFIG_DEBOUNCE_HELPER(led_caps,   EECONFIG_USER_LED_CAPS,   led_config[LED_TYPE_CAPS]);
 
 
+uint8_t host_keyboard_leds(void)
+{
+  return host_led_state.raw;
+}
+
 void usbHidSetStatusLed(uint8_t led_bits)
 {
-  // 받은 LED 상태를 QMK의 공식 LED 설정 함수에 전달합니다.
-  led_set(led_bits);
+  host_led_state.raw = led_bits;  // V251008R8 EP0 컨텍스트에서 직접 LED를 구동하지 않고 QMK 루프에서 처리하도록 저장
 }
 
 void led_init_ports(void)

--- a/src/hw/hw_def.h
+++ b/src/hw/hw_def.h
@@ -6,7 +6,7 @@
 #include QMK_KEYMAP_CONFIG_H
 
 
-#define _DEF_FIRMWATRE_VERSION      "V251008R7"  // V251008R7: 안정 임계 캐시와 HS/FS 단일 비교로 SOF 모니터 경량화
+#define _DEF_FIRMWATRE_VERSION      "V251008R8"  // V251008R8: Caps Lock LED SET_REPORT 비동기화로 USB SOF 공백 제거
 #define _DEF_BOARD_NAME             "BARAM-QMK-H7S-FW"
 
 


### PR DESCRIPTION
## 개요
- Caps Lock LED 상태를 EP0 제어 트랜잭션에서 즉시 구동하지 않고 메인 루프에서 처리하도록 저장하여 SOF 공백을 방지했습니다.
- 펌웨어 버전을 V251008R8로 갱신했습니다.

## 테스트
- cmake -S . -B build -DKEYBOARD_PATH='/keyboards/era/sirind/brick60'
- cmake --build build -j10

------
https://chatgpt.com/codex/tasks/task_e_68e27cc1b18c8332a7952328017b66af