### PR TITLE
BRICK60 LED 인디케이터 테이블 리팩토링 (V251009R2)

### DIFF
--- a/src/hw/hw_def.h
+++ b/src/hw/hw_def.h
@@ -6,7 +6,7 @@
 #include QMK_KEYMAP_CONFIG_H
 
 
-#define _DEF_FIRMWATRE_VERSION      "V251009R1"  // V251009R1: 인디케이터 중복 갱신 최소화 및 설정 변경 최적화
+#define _DEF_FIRMWATRE_VERSION      "V251009R2"  // V251009R2: 인디케이터 테이블 구조 단순화 및 밝기 0 변환 생략
 #define _DEF_BOARD_NAME             "BARAM-QMK-H7S-FW"
 
 


### PR DESCRIPTION
## 요약
- 인디케이터 기본값과 범위를 단일 테이블로 통합하고 EEPROM 플러시 분기를 테이블 기반으로 단순화했습니다.
- LED 설정 명령 처리에서 구성 포인터를 캐싱하고 밝기 0일 때 HSV 변환을 생략하도록 최적화했습니다.
- 펌웨어 버전을 V251009R2로 갱신했습니다.

## 테스트
- cmake -S . -B build -DKEYBOARD_PATH='/keyboards/era/sirind/brick60'
- cmake --build build -j10


------
https://chatgpt.com/codex/tasks/task_e_68e2e5bc49848332916d002571c7bb7b