### PR TITLE
V251009R5: RGBlight 색상 변경 지연 개선

### DIFF
--- a/src/hw/hw_def.h
+++ b/src/hw/hw_def.h
@@ -6,7 +6,7 @@
 #include QMK_KEYMAP_CONFIG_H
 
 
-#define _DEF_FIRMWATRE_VERSION      "V251009R4"  // V251009R4: BRICK60 LED 포트 가드 헬퍼/범위 캐싱 및 리뷰 문서 갱신
+#define _DEF_FIRMWATRE_VERSION      "V251009R5"  // V251009R5: RGBlight 동적 효과 색상 즉시 갱신
 #define _DEF_BOARD_NAME             "BARAM-QMK-H7S-FW"
 
 


### PR DESCRIPTION
## 요약
- RGBlight 동적 효과에서 색상·채도 변경 시 애니메이션을 즉시 재시작하도록 동기화 플래그를 추가했습니다.
- 애니메이션 재시작 시 첫 프레임을 바로 렌더링해 VIA에서 색상 변경을 입력하면 즉시 LED에 반영되도록 조정했습니다.
- 펌웨어 버전 문자열을 V251009R5로 갱신했습니다.

## 테스트
- cmake -S . -B build -DKEYBOARD_PATH='/keyboards/era/sirind/brick60'
- cmake --build build -j10


------
https://chatgpt.com/codex/tasks/task_e_68e2f23172688332882bb62bcb01fd8a