### PR TITLE
SOLID 효과 HSV 즉시 반영 수정

### DIFF
--- a/src/ap/modules/qmk/quantum/rgb_matrix/rgb_matrix.c
+++ b/src/ap/modules/qmk/quantum/rgb_matrix/rgb_matrix.c
@@ -574,6 +574,7 @@ void rgb_matrix_sethsv_eeprom_helper(uint16_t hue, uint8_t sat, uint8_t val, boo
     rgb_matrix_config.hsv.h = hue;
     rgb_matrix_config.hsv.s = sat;
     rgb_matrix_config.hsv.v = (val > RGB_MATRIX_MAXIMUM_BRIGHTNESS) ? RGB_MATRIX_MAXIMUM_BRIGHTNESS : val;
+    rgb_task_state = STARTING;  // V251009R5 SOLID 정적효과 HSV/밝기 변경 시 즉시 렌더링 재시작
     eeconfig_flag_rgb_matrix(write_to_eeprom);
     dprintf("rgb matrix set hsv [%s]: %u,%u,%u\n", (write_to_eeprom) ? "EEPROM" : "NOEEPROM", rgb_matrix_config.hsv.h, rgb_matrix_config.hsv.s, rgb_matrix_config.hsv.v);
 }

--- a/src/hw/hw_def.h
+++ b/src/hw/hw_def.h
@@ -6,7 +6,7 @@
 #include QMK_KEYMAP_CONFIG_H
 
 
-#define _DEF_FIRMWATRE_VERSION      "V251009R4"  // V251009R4: BRICK60 LED 포트 가드 헬퍼/범위 캐싱 및 리뷰 문서 갱신
+#define _DEF_FIRMWATRE_VERSION      "V251009R5"  // V251009R5: SOLID RGB HSV/밝기 변경 지연 해소
 #define _DEF_BOARD_NAME             "BARAM-QMK-H7S-FW"
 
 


### PR DESCRIPTION
## 요약
- SOLID 정적효과에서 HSV/밝기 변경 시 렌더링을 즉시 재시작하여 이전 값이 지연 적용되는 문제를 수정했습니다.
- 펌웨어 버전 문자열을 V251009R5로 갱신했습니다.

## 테스트
- cmake -S . -B build -DKEYBOARD_PATH='/keyboards/era/sirind/brick60'
- cmake --build build -j10


------
https://chatgpt.com/codex/tasks/task_e_68e2fe7dff888332a3adf2c4fade8653