### PR TITLE
V251009R5: 정적 RGB 효과 즉시 반영 수정

### DIFF
--- a/src/hw/hw_def.h
+++ b/src/hw/hw_def.h
@@ -6,7 +6,7 @@
 #include QMK_KEYMAP_CONFIG_H
 
 
-#define _DEF_FIRMWATRE_VERSION      "V251009R4"  // V251009R4: BRICK60 LED 포트 가드 헬퍼/범위 캐싱 및 리뷰 문서 갱신
+#define _DEF_FIRMWATRE_VERSION      "V251009R5"  // V251009R5: 정적 RGB 효과 즉시 적용 순서 보정
 #define _DEF_BOARD_NAME             "BARAM-QMK-H7S-FW"
 
 


### PR DESCRIPTION
## 요약
- 정적 RGB 효과에서 HSV 설정을 먼저 저장하도록 순서를 보정하여 VIA 제어 시 직전 단계가 지연 적용되는 문제를 해결했습니다.
- 펌웨어 버전 문자열을 V251009R5로 갱신했습니다.

## 테스트
- cmake -S . -B build -DKEYBOARD_PATH='/keyboards/era/sirind/brick60'
- cmake --build build -j10


------
https://chatgpt.com/codex/tasks/task_e_68e309f82ac88332869b02e8b4d28d7c