### PR TITLE
V251009R7: BRICK60 인디케이터 포인터 재사용 정리

### DIFF
--- a/src/hw/hw_def.h
+++ b/src/hw/hw_def.h
@@ -6,7 +6,7 @@
 #include QMK_KEYMAP_CONFIG_H
 
 
-#define _DEF_FIRMWATRE_VERSION      "V251009R6"  // V251009R6: LED 타입 가드 일관화 및 EEPROM 검증 안전성 보강
+#define _DEF_FIRMWATRE_VERSION      "V251009R7"  // V251009R7: 인디케이터 포인터 재사용 및 합성 루프 가드 정리
 #define _DEF_BOARD_NAME             "BARAM-QMK-H7S-FW"
 
 


### PR DESCRIPTION
## 요약
- BRICK60 LED 포트에서 인디케이터 루프가 LED 설정 포인터를 재사용하도록 리팩토링해 가드 로직과 캐시 활용을 명확화했습니다.
- 인디케이터 헬퍼 시그니처 변경 및 문서화로 검토 결과와 적용 여부를 V251009R7 기준으로 정리했습니다.
- 펌웨어 버전 문자열을 V251009R7로 갱신했습니다.

## 테스트
- cmake -S . -B build -DKEYBOARD_PATH='/keyboards/era/sirind/brick60'
- cmake --build build -j10


------
https://chatgpt.com/codex/tasks/task_e_68e314e2183c8332996f67babfd5d16e