### PR TITLE
V251009R9: VIA 페이로드 길이 검증과 오류 전파 보강

### DIFF
--- a/src/hw/hw_def.h
+++ b/src/hw/hw_def.h
@@ -6,7 +6,7 @@
 #include QMK_KEYMAP_CONFIG_H
 
 
-#define _DEF_FIRMWATRE_VERSION      "V251009R8"  // V251009R8: VIA 명령 길이 검증 및 RGB 캐시 범위 가드 보강
+#define _DEF_FIRMWATRE_VERSION      "V251009R9"  // V251009R9: VIA 페이로드 길이 가드 및 에러 전파 강화
 #define _DEF_BOARD_NAME             "BARAM-QMK-H7S-FW"
 
 


### PR DESCRIPTION
## 요약
- VIA LED 서브커맨드 처리부에 페이로드 길이 검증을 추가하고 성공 여부를 반환하도록 개편해 짧은 패킷으로 인한 접근 오류를 방지했습니다.
- `via_qmk_led_command()`에서 서브커맨드 실패 시 `id_unhandled`를 통지하도록 수정해 호스트가 오류 상황을 명확히 인지할 수 있게 했습니다.
- 개선 사항을 `docs/led_port.md`에 정리하고 펌웨어 버전을 V251009R9로 갱신했습니다.

## 테스트
- `cmake -S . -B build -DKEYBOARD_PATH='/keyboards/era/sirind/brick60'`
- `cmake --build build -j10`


------
https://chatgpt.com/codex/tasks/task_e_68e31ac9d6a48332a65341045cc91e5e