### PR TITLE
V251010R1: WS2812 DMA 비동기 서비스 이관

### DIFF
--- a/src/ap/modules/qmk/keyboards/era/sirind/brick60/port/driver/rgblight_drivers.c
+++ b/src/ap/modules/qmk/keyboards/era/sirind/brick60/port/driver/rgblight_drivers.c
@@ -13,7 +13,8 @@ void ws2812_setleds(rgb_led_t *ledarray, uint16_t leds)
     b = ledarray[i].b;
     ws2812SetColor(HW_WS2812_RGB + i, WS2812_COLOR(r, g, b));
   }
-  ws2812Refresh();
+  // V251010R1 WS2812 DMA 재기동을 메인 루프로 이관
+  ws2812RequestRefresh(leds);
 }
 
 

--- a/src/ap/modules/qmk/quantum/rgb_matrix/rgb_matrix.c
+++ b/src/ap/modules/qmk/quantum/rgb_matrix/rgb_matrix.c
@@ -29,6 +29,10 @@
 
 #include <lib/lib8tion/lib8tion.h>
 
+#ifdef _USE_HW_WS2812
+#    include "ws2812.h"  // V251010R1 WS2812 DMA 서비스 연동
+#endif
+
 #ifndef RGB_MATRIX_CENTER
 const led_point_t k_rgb_matrix_center = {112, 32};
 #else
@@ -383,6 +387,10 @@ void rgb_matrix_task(void) {
             rgb_task_sync();
             break;
     }
+
+#ifdef _USE_HW_WS2812
+    ws2812ServicePending();  // V251010R1 WS2812 DMA 요청 처리
+#endif
 }
 
 void rgb_matrix_indicators(void) {

--- a/src/ap/modules/qmk/quantum/rgblight/rgblight.c
+++ b/src/ap/modules/qmk/quantum/rgblight/rgblight.c
@@ -24,6 +24,9 @@
 #include "util.h"
 #include "led_tables.h"
 #include <lib/lib8tion/lib8tion.h>
+#ifdef _USE_HW_WS2812
+#    include "ws2812.h"  // V251010R1 WS2812 DMA 서비스 연동
+#endif
 #ifdef EEPROM_ENABLE
 #    include "eeprom.h"
 #endif
@@ -1571,6 +1574,9 @@ void rgblight_task(void) {
     }
 #endif
 
+#ifdef _USE_HW_WS2812
+    ws2812ServicePending();  // V251010R1 WS2812 DMA 요청 처리
+#endif
 }
 
 #ifdef VELOCIKEY_ENABLE

--- a/src/common/hw/include/ws2812.h
+++ b/src/common/hw/include/ws2812.h
@@ -23,6 +23,9 @@ extern "C" {
 bool ws2812Init(void);
 void ws2812SetColor(uint32_t ch, uint32_t color);
 bool ws2812Refresh(void);
+void ws2812RequestRefresh(uint16_t leds);                  // V251010R1 WS2812 DMA 비동기 요청 API
+void ws2812ServicePending(void);                           // V251010R1 WS2812 DMA 서비스 헬퍼
+bool ws2812HandleDmaTransferCompleteFromISR(TIM_HandleTypeDef *htim);  // V251010R1 WS2812 DMA 완료 처리
 
 
 #endif

--- a/src/hw/driver/usb/usb_hid/usbd_hid.c
+++ b/src/hw/driver/usb/usb_hid/usbd_hid.c
@@ -49,6 +49,9 @@
 #include "keys.h"
 #include "qbuffer.h"
 #include "report.h"
+#ifdef _USE_HW_WS2812
+#include "ws2812.h"  // V251010R1 WS2812 DMA 완료 처리 연동
+#endif
 
 
 #if HW_USB_LOG == 1
@@ -1807,6 +1810,12 @@ volatile uint32_t timer_end = 0;
 
 void HAL_TIM_PWM_PulseFinishedCallback(TIM_HandleTypeDef *htim)
 {
+#ifdef _USE_HW_WS2812
+  if (ws2812HandleDmaTransferCompleteFromISR(htim))
+  {
+    return;  // V251010R1 WS2812 DMA 인터럽트 분리 처리
+  }
+#endif
   timer_cnt++;
   timer_end = micros()-rate_time_sof_pre;
 

--- a/src/hw/hw_def.h
+++ b/src/hw/hw_def.h
@@ -6,7 +6,7 @@
 #include QMK_KEYMAP_CONFIG_H
 
 
-#define _DEF_FIRMWATRE_VERSION      "V251009R9"  // V251009R9: VIA 페이로드 길이 가드 및 에러 전파 강화
+#define _DEF_FIRMWATRE_VERSION      "V251010R1"  // V251010R1: WS2812 DMA 비동기 서비스 이관
 #define _DEF_BOARD_NAME             "BARAM-QMK-H7S-FW"
 
 


### PR DESCRIPTION
## 요약
- WS2812 DMA 재기동을 메인 루프 플로우로 이관해 EP0 인터럽트 점유 시간을 제거했습니다.
- rgblight와 USB TIM 콜백을 보완해 DMA 완료 후 요청이 누락되지 않도록 했습니다.
- rgb_matrix 주기 작업에서도 WS2812 요청을 즉시 서비스해 rgblight 외 경로에서도 DMA 재기동 지연을 해소했습니다.
- 펌웨어 버전을 V251010R1로 갱신했습니다.

## 테스트
- cmake -S . -B build -DKEYBOARD_PATH='/keyboards/era/sirind/brick60'
- cmake --build build -j10


------
https://chatgpt.com/codex/tasks/task_e_68e4be4817508332a8a069ae5ddb4d77