### PR TITLE
V251010R2 USB 호스트 LED 비동기 처리 전환

### DIFF
--- a/docs/V251010R2.md
+++ b/docs/V251010R2.md
@@ -1,0 +1,35 @@
+# V251010R2 USB 호스트 LED 비동기 처리 적용 상세
+
+## 1. 적용 배경
+- V251010R1에서 WS2812 DMA 서비스는 메인 루프로 이관했지만, Caps Lock `SET_REPORT` 처리 경로가 여전히 USB ISR에서 RGB 합성 전체를 수행하여 약 7.5 ms 동안 EP0 인터럽트를 점유했습니다.
+- docs/V251010R1.md에서 제안한 대로 호스트 LED 갱신 자체를 메인 루프로 이동시켜 USB 마이크로프레임 공백을 제거하기 위해 본 수정(V251010R2)을 반영했습니다.
+
+## 2. 소스 변경 요약
+### 2.1 `src/ap/modules/qmk/keyboards/era/sirind/brick60/port/led_port.c`
+- `cmsis_compiler.h`를 포함해 PRIMASK 세이브/복원을 위한 CMSIS 헬퍼를 사용하도록 준비했습니다.
+- USB ISR에서 수신한 LED 비트를 저장하는 `host_led_pending_bits`, 플래그 `host_led_dirty`를 `volatile`로 추가하여 인터럽트/메인 루프 간 공유 상태를 마련했습니다.
+- `led_port_enter_critical()`/`led_port_exit_critical()`를 새로 구현해 PRIMASK 상태를 보존하면서 짧은 크리티컬 섹션을 형성하도록 했습니다.
+- `service_pending_host_led()`를 도입해 메인 루프(= `host_keyboard_leds()` 호출 시점)에서만 큐잉된 호스트 LED 상태를 실제 `host_led_state`에 반영하도록 했습니다.
+- `usbHidSetStatusLed()`는 이제 인터럽트 컨텍스트에서 `host_led_pending_bits`만 갱신하고 dirty 플래그만 세팅하도록 단순화했습니다.
+- `host_keyboard_leds()`는 반환 전에 `service_pending_host_led()`를 호출해 메인 루프에서 비동기 상태를 소화하도록 변경했습니다.
+
+### 2.2 `src/hw/hw_def.h`
+- 펌웨어 버전을 `V251010R2`로 갱신하고 주석에 USB 호스트 LED 비동기 전환 내용을 명시했습니다.
+
+## 3. 동작 흐름 변화
+1. USB ISR(`USBD_HID_EP0_RxReady`)이 `usbHidSetStatusLed()`를 호출하면, ISR은 마지막 호스트 LED 비트만 큐잉하고 빠르게 복귀합니다.
+2. 메인 루프에서 `led_task()`가 `host_keyboard_leds()`를 읽을 때 `service_pending_host_led()`가 실행되어 큐잉된 값을 `host_led_state`에 반영합니다.
+3. `led_task()`는 값이 변경된 경우에만 `led_set()`을 호출하고, 이후 `led_update_ports()`가 인디케이터 갱신과 WS2812 리프레시 요청을 담당해 모든 고비용 처리를 메인 루프에서 수행합니다.
+4. `ws2812ServicePending()` 호출 위치는 기존과 동일하게 유지되어 WS2812 DMA는 계속 루프 말미에서 비동기 처리됩니다.
+
+## 4. 동시성/안전성 고려
+- PRIMASK를 저장/복원하는 헬퍼를 통해 인터럽트가 중첩된 상황에서도 기존 상태를 복원하도록 구현했습니다.
+- `host_led_pending_bits`와 `host_led_dirty`는 `volatile`로 선언해 ISR과 메인 루프 간 최적화로 인한 레이스를 차단했습니다.
+- 메인 루프에서만 `host_led_state`를 갱신하므로 `led_task()` 및 인디케이터 캐시 갱신 경로와의 일관성을 확보했습니다.
+
+## 5. 테스트
+- `cmake -S . -B build -DKEYBOARD_PATH='/keyboards/era/sirind/brick60'`
+- `cmake --build build -j10`
+- `rm -rf build`
+
+빌드가 정상적으로 완료되어 컴파일 타임 회귀는 확인되지 않았습니다.

--- a/src/hw/hw_def.h
+++ b/src/hw/hw_def.h
@@ -6,7 +6,7 @@
 #include QMK_KEYMAP_CONFIG_H
 
 
-#define _DEF_FIRMWATRE_VERSION      "V251010R1"  // V251010R1: WS2812 DMA 비동기 서비스 이관
+#define _DEF_FIRMWATRE_VERSION      "V251010R2"  // V251010R2: USB 호스트 LED 비동기 처리 전환
 #define _DEF_BOARD_NAME             "BARAM-QMK-H7S-FW"
 
 


### PR DESCRIPTION
## 요약
- USB HID SET_REPORT 경로에서 호스트 LED 계산을 인터럽트 밖으로 옮기고 PRIMASK 기반 크리티컬 섹션을 추가해 메인 루프에서 비동기 처리하도록 했습니다.
- 펌웨어 버전을 V251010R2로 갱신하고 변경 내역 문서를 추가했습니다.

## 테스트
- cmake -S . -B build -DKEYBOARD_PATH='/keyboards/era/sirind/brick60'
- cmake --build build -j10

------
https://chatgpt.com/codex/tasks/task_e_68e4d8700af08332adb4612d57b54672