### PR TITLE
V251010R6 LED 큐 및 WS2812 서비스 경량화

### DIFF
--- a/src/ap/modules/qmk/quantum/keyboard.c
+++ b/src/ap/modules/qmk/quantum/keyboard.c
@@ -810,10 +810,7 @@ void quantum_task(void) {
 void keyboard_task(void) {
     __attribute__((unused)) bool activity_has_occurred = false;
 #ifdef _USE_HW_USB
-    if (usbHidStatusLedPending())
-    {
-        usbHidServiceStatusLed();  // V251010R5 USB 호스트 LED 큐 선행 처리
-    }
+    usbHidServiceStatusLed();  // V251010R6 USB 호스트 LED 큐 직접 서비스로 크리티컬 섹션 축소
 #endif
     if (matrix_task()) {
         last_matrix_activity_trigger();
@@ -905,9 +902,6 @@ void keyboard_task(void) {
 #endif
 
 #ifdef _USE_HW_WS2812
-    if (ws2812HasPendingTransfer())
-    {
-        ws2812ServicePending();  // V251010R5 WS2812 DMA 조건부 서비스
-    }
+    ws2812ServicePending();  // V251010R6 WS2812 DMA 진입 조건 단일화로 인터럽트 토글 최소화
 #endif
 }

--- a/src/common/hw/include/ws2812.h
+++ b/src/common/hw/include/ws2812.h
@@ -24,8 +24,7 @@ bool ws2812Init(void);
 void ws2812SetColor(uint32_t ch, uint32_t color);
 bool ws2812Refresh(void);
 void ws2812RequestRefresh(uint16_t leds);                  // V251010R1 WS2812 DMA 비동기 요청 API
-bool ws2812HasPendingTransfer(void);                       // V251010R5 WS2812 서비스 필요 여부 조회
-void ws2812ServicePending(void);                           // V251010R1 WS2812 DMA 서비스 헬퍼
+void ws2812ServicePending(void);                           // V251010R6 메인 루프 단일 진입 WS2812 DMA 서비스 헬퍼
 bool ws2812HandleDmaTransferCompleteFromISR(TIM_HandleTypeDef *htim);  // V251010R1 WS2812 DMA 완료 처리
 
 

--- a/src/hw/driver/ws2812.c
+++ b/src/hw/driver/ws2812.c
@@ -203,24 +203,12 @@ void ws2812RequestRefresh(uint16_t leds)
   ws2812RestorePrimask(primask);
 }
 
-bool ws2812HasPendingTransfer(void)
-{
-  bool pending = false;
-  uint32_t primask = __get_PRIMASK();
-
-  __disable_irq();
-  pending = ws2812_pending;
-  ws2812RestorePrimask(primask);
-
-  return pending;  // V251010R5 메인 루프에서 WS2812 서비스 필요 여부 조회
-}
-
 void ws2812ServicePending(void)
 {
   uint16_t transfer_len = 0;
   uint32_t primask = __get_PRIMASK();
 
-  __disable_irq();
+  __disable_irq();                                                    // V251010R6 메인 루프 단일 호출 경량화
   if (ws2812_pending && ws2812_busy == false)
   {
     ws2812_pending = false;

--- a/src/hw/hw_def.h
+++ b/src/hw/hw_def.h
@@ -6,7 +6,7 @@
 #include QMK_KEYMAP_CONFIG_H
 
 
-#define _DEF_FIRMWATRE_VERSION      "V251010R5"  // V251010R5: LED 큐 선행 처리 및 WS2812 조건부 DMA 서비스
+#define _DEF_FIRMWATRE_VERSION      "V251010R6"  // V251010R6: LED 큐/WS2812 서비스 단일화로 크리티컬 섹션 감소
 #define _DEF_BOARD_NAME             "BARAM-QMK-H7S-FW"
 
 


### PR DESCRIPTION
## 요약
- `keyboard_task()`에서 호스트 LED 큐를 바로 서비스하도록 조정해 중복 크리티컬 섹션을 제거했습니다. (V251010R6)
- WS2812 서비스 진입 조건을 단일화하고 헤더/문서를 정리하여 DMA 요청 경량화를 반영했습니다. (V251010R6)
- 펌웨어 버전을 V251010R6으로 갱신했습니다.

## 테스트
- (미실행)


------
https://chatgpt.com/codex/tasks/task_e_68e64d106a6c8332930d707fe612f3a8