### PR TITLE
WS2812 프레임 길이 캐시화 및 초기화 플래그 정리 (V251010R9)

### DIFF
--- a/src/hw/hw_def.h
+++ b/src/hw/hw_def.h
@@ -6,7 +6,7 @@
 #include QMK_KEYMAP_CONFIG_H
 
 
-#define _DEF_FIRMWATRE_VERSION      "V251010R8"  // V251010R8: LED DMA 커밋 최적화 및 호스트 LED 큐 중복 방지
+#define _DEF_FIRMWATRE_VERSION      "V251010R9"  // V251010R9: WS2812 is_init 정리 및 프레임 길이 캐시화
 #define _DEF_BOARD_NAME             "BARAM-QMK-H7S-FW"
 
 


### PR DESCRIPTION
## 요약
- WS2812 드라이버에서 사용되지 않는 is_init 전역 플래그를 제거했습니다.
- WS2812 전체 프레임 길이를 초기화 시 캐시하고 기본 요청에서는 캐시 값을 재사용하도록 조정했습니다.
- 펌웨어 버전을 V251010R9로 갱신했습니다.

## 테스트
- (미실행)

------
https://chatgpt.com/codex/tasks/task_e_68e6754b404883328c35e5c769d7b9e3